### PR TITLE
Remove permissions section from PR lint build workflow

### DIFF
--- a/.github/workflows/pr-lint-build.yml
+++ b/.github/workflows/pr-lint-build.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Removed unnecessary permissions setting for contents.