### PR TITLE
Fix DHI.io registry issue in CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,16 @@
     "config:recommended",
     "mergeConfidence:all-badges",
     "helpers:pinGitHubActionDigests"
+  ],
+  "registryAliases": {
+    "dhi.io": "dhi.io"
+  },
+  "hostRules": [
+    {
+      "matchHost": "dhi.io",
+      "hostType": "docker",
+      "username": "{{ vars.DOCKERHUB_USERNAME }}",
+      "password": "{{ secrets.DHI_TOKEN }}"
+    }
   ]
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to support private Docker registry authentication for `dhi.io`. The most important changes are:

**Private Docker Registry Support:**

* Added a `registryAliases` entry to map `dhi.io` to itself, enabling Renovate to recognize and handle this registry.
* Introduced a `hostRules` block for `dhi.io` with Docker authentication using repository variables and secrets, allowing Renovate to access private images.