### PR TITLE
Fix Docker pnpm workspace configuration for installation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,7 @@ on:
       - "next.config.ts"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - "tsconfig.json"
   workflow_dispatch:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM dhi.io/node:24-debian13-dev AS dependencies
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
   corepack enable \


### PR DESCRIPTION
This pull request makes minor updates to ensure that the `pnpm-workspace.yaml` file is included in both the Docker build context and the workflow triggers. This helps maintain consistency in dependency management and ensures that Docker builds and workflows are aware of workspace changes.

- Docker build improvements:
  * Updated the `Dockerfile` to copy `pnpm-workspace.yaml` into the build context, ensuring all workspace dependencies are correctly recognized during the build process.

- Workflow configuration:
  * Modified `.github/workflows/docker-publish.yml` to trigger the workflow when `pnpm-workspace.yaml` is changed, ensuring that workspace changes are not missed in automated builds.