### PR TITLE
Add Renovate preset for npm minimum release age

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     "mergeConfidence:all-badges",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    "security:minimumReleaseAgeNpm"
   ]
 }
 


### PR DESCRIPTION
This pull request updates the Renovate configuration to improve dependency management security by ensuring only sufficiently aged npm releases are considered for updates.

Dependency management and security:

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3L6-R7): Added the `security:minimumReleaseAgeNpm` preset, which restricts dependency updates to npm releases that have been available for a minimum period, reducing the risk of adopting compromised or unstable packages.