### PR TITLE
Enhance project tracker with star feature and sorting fix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,4 +7,3 @@
     "security:minimumReleaseAgeNpm"
   ]
 }
-

--- a/app/lib/github-transformers.ts
+++ b/app/lib/github-transformers.ts
@@ -39,7 +39,7 @@ export function transformRepoData(
       const status: RepoStatus = getRepoStatus(repo);
       return {
         id: repo.id,
-        name: capitalizeWords(repo.name.replace(/-/g, " ")),
+        name: capitalizeWords(repo.name.replace(/-/g, " ").trim()),
         private: repo.private,
         url: repo.html_url,
         description: repo.description || "No description",
@@ -81,7 +81,8 @@ export function transformGistData(
           firstFile
             .replace(/-/g, " ")
             .replace(/_/g, " ")
-            .replace(/\.(py|md|bash|sh)/g, ""),
+            .replace(/\.(py|md|bash|sh)/g, "")
+            .trim(),
         ),
         public: gist.public,
         url: gist.html_url,

--- a/app/lib/github-transformers.ts
+++ b/app/lib/github-transformers.ts
@@ -16,6 +16,7 @@ type GithubRepoTransformInput = GithubRepoStatusInput & {
   description: string | null;
   topics: string[];
   fork: boolean;
+  stargazers_count: number;
 };
 
 type GithubGistTransformInput = GithubGistStatusInput & {
@@ -46,6 +47,7 @@ export function transformRepoData(
         topics: repo.topics || [],
         projectType: repo.fork ? "Fork" : "Repo",
         status,
+        starCount: repo.stargazers_count,
         lastCommitRelative: formatTimeSinceLastCommit(repo.pushed_at),
         lastCommitTimestamp: new Date(repo.pushed_at).getTime(),
       };
@@ -86,6 +88,7 @@ export function transformGistData(
         description: cleanedDescription,
         projectType: "Gist",
         status,
+        starCount: null,
         lastCommitRelative: formatTimeSinceLastCommit(gist.updated_at),
         lastCommitTimestamp: new Date(gist.updated_at).getTime(),
       };

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -9,6 +9,7 @@ export interface TrackedProject {
   name: string;
   projectType: string;
   status: RepoStatus;
+  starCount: number | null;
   lastCommitRelative: string;
   lastCommitTimestamp: number;
   description: string;

--- a/app/project-tracker/components/project-tracker-columns.tsx
+++ b/app/project-tracker/components/project-tracker-columns.tsx
@@ -7,12 +7,47 @@ type StrictProjectCol = Omit<GridColDef<TrackedProject>, "field"> & {
   field: keyof TrackedProject;
 };
 
+const textSortCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base",
+});
+
+function compareTextValues(valueA: unknown, valueB: unknown): number {
+  return textSortCollator.compare(
+    String(valueA ?? "").trim(),
+    String(valueB ?? "").trim(),
+  );
+}
+
+function compareNumberValues(valueA: unknown, valueB: unknown): number {
+  const numberA = typeof valueA === "number" ? valueA : 0;
+  const numberB = typeof valueB === "number" ? valueB : 0;
+
+  return numberA - numberB;
+}
+
+function getNullableNumberComparator(
+  sortDirection: "asc" | "desc" | null | undefined,
+) {
+  return (valueA: unknown, valueB: unknown): number => {
+    const hasNumberA = typeof valueA === "number";
+    const hasNumberB = typeof valueB === "number";
+
+    if (!hasNumberA && !hasNumberB) return 0;
+    if (!hasNumberA) return 1;
+    if (!hasNumberB) return -1;
+
+    return sortDirection === "desc" ? valueB - valueA : valueA - valueB;
+  };
+}
+
 export const projectTrackerColumns: StrictProjectCol[] = [
   {
     field: "name",
     headerName: "Project Name",
     flex: 1,
     minWidth: 200,
+    sortComparator: compareTextValues,
     renderCell: (params) => {
       return (
         <Link
@@ -26,7 +61,12 @@ export const projectTrackerColumns: StrictProjectCol[] = [
       );
     },
   },
-  { field: "projectType", headerName: "Type", width: 120 },
+  {
+    field: "projectType",
+    headerName: "Type",
+    width: 120,
+    sortComparator: compareTextValues,
+  },
   {
     field: "starCount",
     headerName: "Stars",
@@ -34,12 +74,7 @@ export const projectTrackerColumns: StrictProjectCol[] = [
     width: 100,
     align: "left",
     headerAlign: "left",
-    sortComparator: (valueA, valueB) => {
-      const starCountA = typeof valueA === "number" ? valueA : -1;
-      const starCountB = typeof valueB === "number" ? valueB : -1;
-
-      return starCountA - starCountB;
-    },
+    getSortComparator: getNullableNumberComparator,
     renderCell: (params) => {
       return params.row.starCount === null
         ? "-"
@@ -50,6 +85,7 @@ export const projectTrackerColumns: StrictProjectCol[] = [
     field: "status",
     headerName: "Status",
     width: 150,
+    sortComparator: compareTextValues,
     renderCell: (params) => {
       // NOTE: DataGrid cell values are broadly typed; this cast narrows the
       // `status` cell value to our `RepoStatus` union for `StatusBadge`.
@@ -61,8 +97,18 @@ export const projectTrackerColumns: StrictProjectCol[] = [
   {
     field: "lastCommitTimestamp",
     headerName: "Last Commit",
+    type: "number",
     width: 180,
+    align: "left",
+    headerAlign: "left",
+    sortComparator: compareNumberValues,
     renderCell: (params) => params.row.lastCommitRelative,
   },
-  { field: "description", headerName: "Description", flex: 2, minWidth: 300 },
+  {
+    field: "description",
+    headerName: "Description",
+    flex: 2,
+    minWidth: 300,
+    sortComparator: compareTextValues,
+  },
 ];

--- a/app/project-tracker/components/project-tracker-columns.tsx
+++ b/app/project-tracker/components/project-tracker-columns.tsx
@@ -28,6 +28,25 @@ export const projectTrackerColumns: StrictProjectCol[] = [
   },
   { field: "projectType", headerName: "Type", width: 120 },
   {
+    field: "starCount",
+    headerName: "Stars",
+    type: "number",
+    width: 100,
+    align: "left",
+    headerAlign: "left",
+    sortComparator: (valueA, valueB) => {
+      const starCountA = typeof valueA === "number" ? valueA : -1;
+      const starCountB = typeof valueB === "number" ? valueB : -1;
+
+      return starCountA - starCountB;
+    },
+    renderCell: (params) => {
+      return params.row.starCount === null
+        ? "-"
+        : params.row.starCount.toLocaleString();
+    },
+  },
+  {
     field: "status",
     headerName: "Status",
     width: 150,


### PR DESCRIPTION
This pull request enhances the project tracker by adding support for displaying and sorting repository star counts, as well as improving sorting behavior for several columns. The changes involve backend data transformation, type updates, and significant improvements to the frontend table columns.

**Project tracker enhancements:**

* Added a new `starCount` field to the `TrackedProject` type and ensured it is populated for repositories (with `null` for gists) in the data transformation functions (`transformRepoData` and `transformGistData`). [[1]](diffhunk://#diff-e4d73126cb1ae5c3f0bcd3921e9e369293bc2d5808f82c67b06b0c7fbc43abf5R19) [[2]](diffhunk://#diff-e4d73126cb1ae5c3f0bcd3921e9e369293bc2d5808f82c67b06b0c7fbc43abf5L41-R50) [[3]](diffhunk://#diff-e4d73126cb1ae5c3f0bcd3921e9e369293bc2d5808f82c67b06b0c7fbc43abf5L82-R92) [[4]](diffhunk://#diff-a83dfc0029b915cb25a8dbaf311d1b4112198e7df8a13331c91bdbdced0d01bcR12)
* Added a "Stars" column to the project tracker table, displaying the star count for each project and supporting correct sorting, including handling of null values.

**Sorting improvements:**

* Introduced custom sorting logic for text and number columns using `compareTextValues`, `compareNumberValues`, and `getNullableNumberComparator` for more intuitive sorting across the table. [[1]](diffhunk://#diff-582e7f11f1de9ee7907a55588cb4b38c186cdb4ad7ee14e82b10fc863eb6196bR10-R50) [[2]](diffhunk://#diff-582e7f11f1de9ee7907a55588cb4b38c186cdb4ad7ee14e82b10fc863eb6196bL29-R88) [[3]](diffhunk://#diff-582e7f11f1de9ee7907a55588cb4b38c186cdb4ad7ee14e82b10fc863eb6196bR100-R113)
* Applied the new text and number sort comparators to the "Project Name", "Type", "Status", "Last Commit", and "Description" columns for consistent and accurate sorting behavior. [[1]](diffhunk://#diff-582e7f11f1de9ee7907a55588cb4b38c186cdb4ad7ee14e82b10fc863eb6196bL29-R88) [[2]](diffhunk://#diff-582e7f11f1de9ee7907a55588cb4b38c186cdb4ad7ee14e82b10fc863eb6196bR100-R113)

**Minor cleanup:**

* Removed an unnecessary trailing newline from `.github/renovate.json`.