### PR TITLE
Fix project tracker sorting and row shape

### DIFF
--- a/app/lib/github-transformers.ts
+++ b/app/lib/github-transformers.ts
@@ -35,24 +35,21 @@ export function transformRepoData(
   }
 
   return repos
+    .filter((repo: GithubRepoTransformInput) => !repo.private)
     .map((repo: GithubRepoTransformInput) => {
       const status: RepoStatus = getRepoStatus(repo);
       return {
         id: repo.id,
         name: capitalizeWords(repo.name.replace(/-/g, " ").trim()),
-        private: repo.private,
         url: repo.html_url,
         description: repo.description || "No description",
-        archived: repo.archived,
-        topics: repo.topics || [],
         projectType: repo.fork ? "Fork" : "Repo",
         status,
         starCount: repo.stargazers_count,
         lastCommitRelative: formatTimeSinceLastCommit(repo.pushed_at),
         lastCommitTimestamp: new Date(repo.pushed_at).getTime(),
       };
-    })
-    .filter((repo) => !repo.private); // Filter out private repositories
+    });
 }
 
 export function transformGistData(
@@ -64,6 +61,7 @@ export function transformGistData(
   }
 
   return gists
+    .filter((gist) => gist.public)
     .map((gist) => {
       const status: RepoStatus = getGistStatus(gist);
       const files: string[] = Object.keys(gist.files || {});
@@ -84,7 +82,6 @@ export function transformGistData(
             .replace(/\.(py|md|bash|sh)/g, "")
             .trim(),
         ),
-        public: gist.public,
         url: gist.html_url,
         description: cleanedDescription,
         projectType: "Gist",
@@ -93,6 +90,5 @@ export function transformGistData(
         lastCommitRelative: formatTimeSinceLastCommit(gist.updated_at),
         lastCommitTimestamp: new Date(gist.updated_at).getTime(),
       };
-    })
-    .filter((gist) => gist.public); // Filter out private gists
+    });
 }


### PR DESCRIPTION
This pull request simplifies and clarifies the transformation logic for repositories and gists in `github-transformers.ts` by moving the filtering of private items earlier in the process and cleaning up the returned data structures.

**Repository and Gist Filtering Improvements:**

* Moved the filtering of private repositories and gists to occur before mapping, ensuring only public items are processed and returned in `transformRepoData` and `transformGistData`. [[1]](diffhunk://#diff-e4d73126cb1ae5c3f0bcd3921e9e369293bc2d5808f82c67b06b0c7fbc43abf5R38-R52) [[2]](diffhunk://#diff-e4d73126cb1ae5c3f0bcd3921e9e369293bc2d5808f82c67b06b0c7fbc43abf5R64) [[3]](diffhunk://#diff-e4d73126cb1ae5c3f0bcd3921e9e369293bc2d5808f82c67b06b0c7fbc43abf5L96-R93)

**Data Structure Cleanup:**

* Removed the `private` property from the transformed repository objects and the `public` property from the transformed gist objects, as only public items are now included. [[1]](diffhunk://#diff-e4d73126cb1ae5c3f0bcd3921e9e369293bc2d5808f82c67b06b0c7fbc43abf5R38-R52) [[2]](diffhunk://#diff-e4d73126cb1ae5c3f0bcd3921e9e369293bc2d5808f82c67b06b0c7fbc43abf5L87)