### PR TITLE
Streamline Corepack pnpm commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@
 
 FROM dhi.io/node:24-debian13-dev AS dependencies
 WORKDIR /app
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
-  corepack enable \
-  && pnpm install --frozen-lockfile
+  corepack pnpm install --frozen-lockfile
 
 # ============================================
 # Stage 2: Build Next.js application in standalone moded
@@ -18,14 +18,14 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
 FROM dhi.io/node:24-debian13-dev AS builder
 WORKDIR /app
 ENV NODE_ENV=production
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
 COPY --from=dependencies /app/node_modules ./node_modules
 COPY . .
 
 RUN --mount=type=cache,target=/app/.next/cache \
-  corepack enable \
-  && pnpm build \
-  && pnpm prune --prod --ignore-scripts
+  corepack pnpm build \
+  && corepack pnpm prune --prod --ignore-scripts
 
 # ============================================
 # Stage 3: Run Next.js application


### PR DESCRIPTION
This pull request updates the `Dockerfile` to streamline the use of `pnpm` and ensure non-interactive builds by configuring Corepack and environment variables. The main changes focus on improving build reliability and automation.

**Build process improvements:**

* Added `ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0` to disable interactive Corepack prompts during Docker builds, ensuring builds run smoothly in automated environments. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R7-R12) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R21-R28)
* Replaced separate `corepack enable` and `pnpm` commands with direct `corepack pnpm ...` invocations for both install and build steps, simplifying the Dockerfile and reducing potential issues with Corepack state. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R7-R12) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R21-R28)