### PR TITLE
Make icons optional for item cards

### DIFF
--- a/app/components/item-card.tsx
+++ b/app/components/item-card.tsx
@@ -22,7 +22,9 @@ export default function CardItem({ item, titleSpacing }: CardItemProps) {
   const cardContent = (
     <CardContent>
       <Typography variant="h6" sx={{ mb: titleSpacing }}>
-        <Icon fontSize="small" sx={{ mr: 1, verticalAlign: "text-bottom" }} />
+        {Icon ? (
+          <Icon fontSize="small" sx={{ mr: 1, verticalAlign: "text-bottom" }} />
+        ) : null}
         {item.title}
       </Typography>
       <Typography variant="body2">{item.body}</Typography>

--- a/app/components/link-card-data.tsx
+++ b/app/components/link-card-data.tsx
@@ -6,7 +6,7 @@ export default interface LinkCardData {
   body: string;
   href: string;
   isExternal: boolean;
-  icon: React.ElementType;
+  icon?: React.ElementType;
   category?: "service" | "doc-and-tools";
   color?: string;
 }


### PR DESCRIPTION
This pull request introduces a small UI improvement and a type safety enhancement for card components. The most important changes are:

**Type Safety and Flexibility:**

* Made the `icon` property in the `LinkCardData` interface optional, allowing card items to be created without requiring an icon.

**UI Rendering Logic:**

* Updated `CardItem` to conditionally render the icon only if it is provided, preventing errors and unnecessary rendering when no icon is specified.